### PR TITLE
Fix rule properties exporting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const meta = {
 }
 
 /** @type {import('stylelint').Rule} */
-module.exports = stylelint.createPlugin(ruleName, (primary) => {
+const ruleFunction = (primary) => {
   return (root, result) => {
     const validOptions = stylelint.utils.validateOptions(result, ruleName, {
       actual: primary
@@ -71,7 +71,7 @@ module.exports = stylelint.createPlugin(ruleName, (primary) => {
       })
     })
   }
-})
+}
 
 /**
  * @param {import('postcss').Declaration} decl
@@ -87,6 +87,8 @@ function isInColorGamutP3MediaQuery (decl) {
   return false
 }
 
-module.exports.ruleName = ruleName
-module.exports.messages = messages
-module.exports.meta = meta
+ruleFunction.ruleName = ruleName
+ruleFunction.messages = messages
+ruleFunction.meta = meta
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { messages, ruleName } = require('./index.js')
+const { rule: { messages, ruleName } } = require('./index.js')
 
 testRule({
   ruleName,


### PR DESCRIPTION
It's needed to set properties to the rule function, instead of exporting each property.

Sorry, but the current plugins document on <https://stylelint.io> is outdated. The latest one is on HEAD. We'll update it before long.
See <https://github.com/stylelint/stylelint/blob/613334b7711654bba5a4f75f01780131757f0656/docs/developer-guide/plugins.md>
