### PR TITLE
More standard indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Add `stylelint-gamut` to your Stylelint config `plugins` array, then add rules y
 
 ```json
 {
-	"plugins": [
-		"stylelint-gamut"
-	],
-	"rules": {
-		"gamut/color-no-out-gamut-range": true,
-	}
+  "plugins": [
+    "stylelint-gamut"
+  ],
+  "rules": {
+    "gamut/color-no-out-gamut-range": true,
+  }
 }
 ```
 


### PR DESCRIPTION
2 space indent is much more popular for JSON files.

But I understand that it is just a subjective. Feel free to close if you have rational reasons.