### PR TITLE
Use non-strict peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/fpetrakov/stylelint-gamut#readme",
   "peerDependencies": {
-    "stylelint": "^14.10.0"
+    "stylelint": ">=14.10.0"
   },
   "devDependencies": {
     "eslint": "^8.22.0",


### PR DESCRIPTION
Right now, you will need to release a new version of the plugin on every Stylelint major update.

I think it would take too much time, and it will create more problems.

