### PR TITLE
add check incorrect css custom properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,12 @@ const ruleFunction = (primary) => {
       }
 
       function check (value) {
-        if (!value.startsWith('var(--') && value.includes('var(--')) return
+        if (
+          (!value.startsWith('var(--') && value.includes('var(--')) ||
+          (value.includes('var') && !value.includes('--'))
+        ) {
+          return
+        }
 
         let customPropValue
         if (value.startsWith('var(--')) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -80,6 +80,10 @@ testRule({
     {
       code: 'html {--hover: oklch(58% 0.22 260 / 20%); @media (color-gamut: p3) {--hover: oklch(54% 0.27 260 / 0.2); } } ::selection { background: var(--hover); }',
       description: 'nested'
+    },
+    {
+      code: 'a { background: var(-) }',
+      description: 'should be not fired rule'
     }
   ],
 


### PR DESCRIPTION
Whenever I use the rule on the following piece of code, I get an error.

```css
.field {
  width: var(--field-width);
  height: var(--field-height);

  & [type="text"] {
    width: 100%;
    height: 100%;
    padding: 0 12px;
    background: var(--background);
    border-radius: var(-); /* <- This causes an error */

    &:focus {
      outline-color: var(--accent);
    }
  }
}
```

Error message

![image](https://github.com/fpetrakov/stylelint-gamut/assets/82271383/13182bbd-0839-4d72-ba83-4bcfae4d5fff)

This pr add a check for the correctness of the use of custom css properties. Also added a base test for this case.
